### PR TITLE
Updated to Manifest v3

### DIFF
--- a/manifest.chrome.json
+++ b/manifest.chrome.json
@@ -1,18 +1,14 @@
 {
-	"manifest_version": 2,
+	"manifest_version": 3,
 	"name": "Cookie-Editor",
-	"version": "1.10.1",
+	"version": "1.10.2",
 	"author": "Moustachauve",
 	"description": "Simple yet powerful Cookie Editor that allow you to quickly create, edit and delete cookies without leaving your tab.",
 	"offline_enabled": true,
 	"background": {
-		"scripts": [
-			"interface/lib/browserDetector.js",
-			"cookie-editor.js"
-		],
-		"persistent": false
+		"service_worker": "interface/lib/browserDetector.js"
 	},
-	"browser_action": {
+	"action": {
 		"default_icon": {
 			"16": "icons/cookie-16-filled.png",
 			"19": "icons/cookie-19-filled.png",
@@ -25,10 +21,10 @@
 	"devtools_page": "interface/devtools/devtool.html",
 	"permissions": [
 		"cookies",
-		"<all_urls>",
 		"tabs",
 		"storage"
 	],
+	"host_permissions": ["<all_urls>"],
 	"icons": {
 		"16": "icons/cookie-16-filled.png",
 		"19": "icons/cookie-19-filled.png",


### PR DESCRIPTION
Manifest v2 will be deprecated in June 2023. Hence I've done the required changes. Please verify.

The key background in your manifest.json can no longer contain the field persistent, and also updated the value from scripts to service_worker. Service_worker cannot contain an array but can only contain a single string value. So you need to set "cookie-editor.js" and "browserDetector.js" in the same script to get input from both