### PR TITLE
fix(permission): check and request permission should ignore url port

### DIFF
--- a/interface/lib/permissionHandler.js
+++ b/interface/lib/permissionHandler.js
@@ -49,6 +49,12 @@ export class PermissionHandler {
     const testPermission = {
       origins: [url],
     };
+    try {
+      const { protocol, hostname } = new URL(url);
+      testPermission.origins = [`${protocol}//${hostname}/*`];
+    } catch (err) {
+      console.error(err);
+    }
 
     // If we don't have access to the permission API, assume we have
     // access. Safari devtools can't access the API.
@@ -70,6 +76,12 @@ export class PermissionHandler {
     const permission = {
       origins: [url],
     };
+    try {
+      const { protocol, hostname } = new URL(url);
+      permission.origins = [`${protocol}//${hostname}/*`];
+    } catch (err) {
+      console.error(err);
+    }
     return this.browserDetector.getApi().permissions.request(permission);
   }
 }


### PR DESCRIPTION
The same cookie is shared by different ports of the same domain name. If a port is added when request permission, the urls of different ports of the same domain name cannot access the current cookie. For example, localhost:8080 requires the cookie of localhost

close #66 
close #142 
close #135 