### PR TITLE
Switched from deprecated document.execCommand to the clipboard API

### DIFF
--- a/interface/options/options.js
+++ b/interface/options/options.js
@@ -199,15 +199,7 @@ document.addEventListener('DOMContentLoaded', async (event) => {
    * @param {string} text Text to copy.
    */
   function copyText(text) {
-    const fakeText = document.createElement('textarea');
-    fakeText.classList.add('clipboardCopier');
-    fakeText.textContent = text;
-    document.body.appendChild(fakeText);
-    fakeText.focus();
-    fakeText.select();
-    // TODO: switch to clipboard API.
-    document.execCommand('Copy');
-    document.body.removeChild(fakeText);
+    navigator.clipboard.writeText(text);
   }
 
   /**

--- a/interface/popup/cookie-list.js
+++ b/interface/popup/cookie-list.js
@@ -1202,15 +1202,7 @@ import { CookieHandlerPopup } from './cookieHandlerPopup.js';
    * @param {string} text Text to copy.
    */
   function copyText(text) {
-    const fakeText = document.createElement('textarea');
-    fakeText.classList.add('clipboardCopier');
-    fakeText.textContent = text;
-    document.body.appendChild(fakeText);
-    fakeText.focus();
-    fakeText.select();
-    // TODO: switch to clipboard API.
-    document.execCommand('Copy');
-    document.body.removeChild(fakeText);
+    navigator.clipboard.writeText(text);
   }
 
   /**


### PR DESCRIPTION
I have not been able to test this on any browsers other than Firefox, but I'd expect it to work because the API [seems to be supported](https://caniuse.com/mdn-api_navigator_clipboard) on all major browsers.

Let me know if I'm missing anything :+1: 

