### PR TITLE
Fix bug where showNoCookies animation played regardless of the current page

### DIFF
--- a/interface/popup/cookie-list.js
+++ b/interface/popup/cookie-list.js
@@ -639,6 +639,12 @@ import { CookieHandlerPopup } from './cookieHandlerPopup.js';
     if (disableButtons) {
       return;
     }
+    // If on a different page (e.g: import page) - don't show the no-cookies message.
+    const pageTitle =
+      pageTitleContainer?.querySelector('h1')?.textContent ?? '';
+    if (pageTitle !== 'Cookie-Editor') {
+      return;
+    }
     cookiesListHtml = null;
     const html = document
       .importNode(document.getElementById('tmp-empty').content, true)


### PR DESCRIPTION
The `showNoCookies` function gets called by the `cookiesChange` handler, which in turn is triggered whenever there's some change in the `CookieStore` of the browser.

As far as I can tell, the issue was that a `cookieChange` event would trigger *after* we've already clicked `import`. This would cause `showNoCookies` to be called, and this in turn would trigger an animation.

The fix simply checks what page we're on, if we are *not* on the main page (the `Cookie-Editor` page), then the animation doesn't play. 

I'm not sure if this is an elegant solution, let me know if anything :+1:

Fixes issue #167, as well as all similar issues, for instance, clicking delete all cookies in the popup -> shift+tab -> space.