### PR TITLE
Fix cookie parsing to handle values containing equal signs

### DIFF
--- a/interface/lib/headerstringFormat.js
+++ b/interface/lib/headerstringFormat.js
@@ -16,14 +16,14 @@ export class HeaderstringFormat {
       if (!rawCookie.length) {
         continue;
       }
-      const cookieParts = rawCookie.split('=');
-      if (cookieParts.length != 2) {
+      const eqPos = rawCookie.indexOf('=');
+      if (eqPos === -1) {
         console.log('invalid cookie: ', rawCookie);
         continue;
       }
       cookies.push({
-        name: cookieParts[0],
-        value: cookieParts[1],
+        name: rawCookie.substring(0, eqPos),
+        value: rawCookie.substring(eqPos + 1),
       });
     }
 


### PR DESCRIPTION
Parsing cookie header strings failed when values contained = due to incorrect splitting. (e.g., a=1; b=2=;)